### PR TITLE
Fix variable name in README.md based on cookiecutter.json

### DIFF
--- a/{{cookiecutter.repo_name}}/README.md
+++ b/{{cookiecutter.repo_name}}/README.md
@@ -27,7 +27,7 @@ TODO
 3. Call the plugin:
 
   ```javascript
-  $("#element").{{ cookiecutter.defaultPluginName }}({
+  $("#element").{{ cookiecutter.pluginName }}({
     propertyName: "a custom value"
   });
   ```


### PR DESCRIPTION
I hope `pluginName` is correct. :smile_cat: 
